### PR TITLE
자잘한 사용성 개선

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -9,6 +9,7 @@ module.exports = function (api) {
           moduleName: 'react-native-dotenv',
         },
       ],
+      'react-native-reanimated/plugin',
     ],
   };
 };

--- a/babel.config.js
+++ b/babel.config.js
@@ -9,7 +9,6 @@ module.exports = function (api) {
           moduleName: 'react-native-dotenv',
         },
       ],
-      'react-native-reanimated/plugin',
     ],
   };
 };

--- a/src/modules/products/MainList.tsx
+++ b/src/modules/products/MainList.tsx
@@ -31,6 +31,7 @@ import PreferenceContext from '../../contexts/PreferenceContext';
 import LocaleType from '../../enums/LocaleType';
 import UserContext from '../../contexts/UserContext';
 import { Page, ProductPage } from '../../enums/pageEnum';
+import useSafeAsync from '../../utiles/useSafeAsync';
 
 interface State {
   stories: Story[];
@@ -53,6 +54,7 @@ const MainList: FunctionComponent = () => {
     xOffset: 0,
     yOffset: 0,
   });
+  const safeAsync = useSafeAsync();
 
   const navigation = useNavigation();
   const route = useRoute<RouteProp<ParamList, 'MainList'>>();
@@ -65,16 +67,16 @@ const MainList: FunctionComponent = () => {
   useScrollToTop(ref);
 
   useEffect(() => {
-    Server.storyList(language || LocaleType.EN)
-      .then((res) => {
+    safeAsync(Server.storyList(language || LocaleType.EN))
+      .then((res: any) => {
         setState({ ...state, stories: res.data });
 
-        Server.products().then((res) => {
+        safeAsync(Server.products()).then((res: any) => {
           setState((state) => {
             return {
               ...state,
               products: res.data.filter(
-                (product) => product.status === 'terminated',
+                (product: { status: string; }) => product.status === 'terminated',
               ),
             };
           });
@@ -85,7 +87,7 @@ const MainList: FunctionComponent = () => {
           alert(t('account_errors.server'));
         }
       });
-  }, [language]);
+  }, [language, safeAsync]);
 
   // useFocusEffect(
   //   React.useCallback(() => {

--- a/src/modules/products/components/ExpandedCard.tsx
+++ b/src/modules/products/components/ExpandedCard.tsx
@@ -64,13 +64,13 @@ const defaultTextProps = {
 };
 
 const ELEMENT_HEIGHT = 416;
+const windowWidth = Dimensions.get('window').width;
 
 const AutoSizedImage: FunctionComponent<{
   style?: ImageStyle;
   source: { uri: string };
 }> = (props: { style?: ImageStyle; source: { uri: string } }) => {
   const [state, setState] = useState({ finalSize: { width: 0, height: 0 } });
-  const windowWidth = Dimensions.get('window').width;
   const safeAsync = useSafeAsync();
 
   useEffect(() => {
@@ -227,7 +227,7 @@ const ExpandedItem: FunctionComponent<Props> = ({
             }),
             width: animatedValue.interpolate({
               inputRange: [0, 1],
-              outputRange: ['88.5%', '100%'],
+              outputRange: [windowWidth-xOffset*2, windowWidth],
             }),
             resizeMode: 'cover',
           }}

--- a/src/modules/products/components/ExpandedCard.tsx
+++ b/src/modules/products/components/ExpandedCard.tsx
@@ -226,7 +226,7 @@ const ExpandedItem: FunctionComponent<Props> = ({
             }),
             width: animatedValue.interpolate({
               inputRange: [0, 1],
-              outputRange: [364, 412],
+              outputRange: ['88.5%', '100%'],
             }),
             resizeMode: 'cover',
           }}

--- a/src/modules/products/components/ExpandedCard.tsx
+++ b/src/modules/products/components/ExpandedCard.tsx
@@ -70,14 +70,15 @@ const AutoSizedImage: FunctionComponent<{
   source: { uri: string };
 }> = (props: { style?: ImageStyle; source: { uri: string } }) => {
   const [state, setState] = useState({ finalSize: { width: 0, height: 0 } });
-  const finalSize = {
-    width: 0,
-    height: 0,
-  };
   const windowWidth = Dimensions.get('window').width;
   const safeAsync = useSafeAsync();
 
   useEffect(() => {
+    const finalSize = {
+      width: 0,
+      height: 0,
+    };
+
     if (props.style?.width || props.style?.height) {
       return;
     }

--- a/src/modules/products/components/ExpandedCard.tsx
+++ b/src/modules/products/components/ExpandedCard.tsx
@@ -27,6 +27,7 @@ import { Story } from '../../../types/product';
 import { P1Text, H2Text } from '../../../shared/components/Texts';
 import { Page, ProductPage } from '../../../enums/pageEnum';
 import AppFonts from '../../../enums/AppFonts';
+import useSafeAsync from '../../../utiles/useSafeAsync';
 
 interface Props {
   story: Story;
@@ -69,25 +70,27 @@ const AutoSizedImage: FunctionComponent<{
   source: { uri: string };
 }> = (props: { style?: ImageStyle; source: { uri: string } }) => {
   const [state, setState] = useState({ finalSize: { width: 0, height: 0 } });
+  const finalSize = {
+    width: 0,
+    height: 0,
+  };
   const windowWidth = Dimensions.get('window').width;
+  const safeAsync = useSafeAsync();
 
   useEffect(() => {
     if (props.style?.width || props.style?.height) {
       return;
     }
-    Image.getSize(props.source.uri, (originalWidth, originalHeight) => {
-      const finalSize = {
-        width: originalWidth,
-        height: originalWidth,
-      };
+    safeAsync(Image.getSize(props.source.uri, (originalWidth, originalHeight) => {
+      finalSize.width = originalWidth;
+      finalSize.height = originalHeight;
       if (originalWidth > windowWidth) {
         finalSize.width = windowWidth;
         const ratio = finalSize.width / originalWidth;
         finalSize.height = originalHeight * ratio;
       }
-      setState({
-        finalSize,
-      });
+    })).then(() => {
+      setState({ finalSize });
     });
   }, []);
 

--- a/src/shared/components/CryptoImage.tsx
+++ b/src/shared/components/CryptoImage.tsx
@@ -2,43 +2,56 @@ import React from 'react'
 import { Image, ImageStyle, StyleProp } from "react-native"
 import CryptoType from '../../enums/CryptoType'
 import PaymentCryptoType from '../../enums/PaymentCryptoType'
+import CachedImage from './CachedImage'
 
 const CryptoImage: React.FC<{ type: CryptoType | PaymentCryptoType | string, style?: StyleProp<ImageStyle> }> = ({ type, style }) => {
   const SwitchIcon = (type: CryptoType | PaymentCryptoType | string) => {
     switch (type) {
       case CryptoType.EL:
-      case PaymentCryptoType.EL: 
+      case PaymentCryptoType.EL:
         return require('../assets/images/el.png')
-        break;
       case CryptoType.ETH:
       case PaymentCryptoType.ETH:
         return require('../assets/images/eth.png')
-        break;
       case CryptoType.BNB:
       case PaymentCryptoType.BNB:
         return require('../assets/images/bnb.png')
-        break;
       case CryptoType.ELA:
         return require('../assets/images/asset.png')
-        break;
       case "none":
         return
       default:
         return {uri: type}
-        break;
     }
   }
-  return (
-    <Image
-      source={SwitchIcon(type)}
-      style={{
-        width: 40,
-        height: 40,
-        borderRadius: 40,
-        ...style as {},
-      }}
-    />
-  )
+
+  const image = SwitchIcon(type)
+  if (typeof image === 'object') {
+    return (
+      <CachedImage
+        source={image}
+        cacheKey={image.uri.replace(/\//g, '_')}
+        style={{
+          width: 40,
+          height: 40,
+          borderRadius: 40,
+          ...style as {},
+        }}
+      />
+    )
+  } else {
+    return (
+      <Image
+        source={image}
+        style={{
+          width: 40,
+          height: 40,
+          borderRadius: 40,
+          ...style as {},
+        }}
+      />
+    )
+  }
 }
 
 export default CryptoImage

--- a/src/utiles/useSafeAsync.tsx
+++ b/src/utiles/useSafeAsync.tsx
@@ -1,0 +1,33 @@
+import { useRef, useCallback, useEffect } from 'react';
+
+const useMountedState = () => {
+  const mountedRef = useRef(false);
+  const isMounted = useCallback(() => mountedRef.current, []);
+
+  useEffect(() => {
+    mountedRef.current = true;
+
+    return () => {
+      mountedRef.current = false;
+    }
+  }, []);
+
+  return isMounted;
+};
+
+const useSafeAsync = () => {
+  const isMounted = useMountedState();
+  const safeAsync = useCallback((promise) => {
+    return new Promise((resolve) => {
+      promise.then((value: unknown) => {
+        if (isMounted()) {
+          resolve(value);
+        }
+      });
+    });
+  }, []);
+
+  return safeAsync;
+};
+
+export default useSafeAsync;


### PR DESCRIPTION
### 한 일
1. 하단 내비게이션 탭을 옮겨다닐 때마다 뜨던 ajax 관련 워닝이 뜨지 않도록 했습니다. [참고한 링크](https://www.benmvp.com/blog/handling-async-react-component-effects-after-unmount/)
2. 안드로이드에서 스토리 카드를 누를 때 애니메이션이 버벅이는 문제를 해결했습니다. 처음에는 안드로이드에서만 `react-native-reanimated` 라이브러리를 사용하려고 했는데, 이미지가 깜박이는 문제를 해결하지 못 해서... reanimated 라이브러리를 사용하지 않는 대신 css transform 속성에 애니메이션을 적용하는 방향으로 다시 구현했습니다. 애니메이션을 구현할 때는 cpu를 사용하는 top 같은 속성을 직접 조작하는 것보다 gpu를 사용하는 transform을 쓰는 것이 더 빠르다고 합니다. [출처](https://mygumi.tistory.com/238)
3. (추가) 메인 페이지에서 '내 투자금'의 상품 이미지들에 캐시를 적용했습니다. '내 투자금'과 '내 지갑'의 이미지들이 둘 다 CryptoImage 컴포넌트를 쓰고 있는데, '내 투자금' 이미지들만 외부에서 불러오고 있어서 if문을 사용해 전자에는 CachedImage를 사용하고 후자는 이전처럼 Image를 그대로 사용하는 것으로 경우를 나눴습니다. 

### 궁금한 점
* react-native-reanimated를 사용해서 구현했던 커밋은 기록에서 지우고 풀리퀘스트를 보내는 것이 나을까요?