### PR TITLE
iOS에서 부동산 구매 시 OverlayLoading이 제대로 사라지지 않는 문제 해결

### DIFF
--- a/src/modules/asset/Purchase.tsx
+++ b/src/modules/asset/Purchase.tsx
@@ -50,8 +50,6 @@ const Purchase: FunctionComponent = () => {
     isApproved: [CryptoType.ETH, CryptoType.BNB].includes(from.type) ? true : false,
   });
   const [current, setCurrent] = useState<'from' | 'to'>('to');
-  // const route = useRoute<RouteProp<ParamList, 'Purchase'>>();
-  // const { from, to, toMax, contractAddress, productId } = route.params;
   const navigation = useNavigation();
   const { isWalletUser, Server } = useContext(UserContext);
   const { wallet } = useContext(WalletContext);
@@ -63,7 +61,6 @@ const Purchase: FunctionComponent = () => {
   const { afterTxFailed, afterTxHashCreated, afterTxCreated } = useTxHandler();
   const { t } = useTranslation();
   const contract = getAssetTokenFromCryptoType(from.type, contractAddress);
-  // const [isApproved, setIsApproved] = useState([CryptoType.ETH, CryptoType.BNB].includes(from.type) ? true : false);
   const { getBalance } = useContext(AssetContext);
 
   const fromMax = (toMax || 0) * 5 / getCryptoPrice(from.type);
@@ -188,7 +185,6 @@ const Purchase: FunctionComponent = () => {
             wallet?.getFirstNode()?.address, contractAddress
           ).then((res: BigNumber) => {
             if (!res.isZero()) {
-              // setIsApproved(true);
               setState({
                 ...state,
                 isApproved: true,
@@ -201,7 +197,6 @@ const Purchase: FunctionComponent = () => {
                 step: TxStep.None,
               })
             }
-            // setState({ ...state, step: TxStep.None })
           }).catch((e: any) => {
             afterTxFailed(e.message);
             navigation.goBack();
@@ -219,8 +214,6 @@ const Purchase: FunctionComponent = () => {
               to: populatedTransaction.to,
               data: populatedTransaction.data,
             }).then((tx: any) => {
-              // setIsApproved(true);
-              // setState({ ...state, txHash: tx, step: TxStep.None })
               setState({
                 ...state,
                 isApproved: true,

--- a/src/modules/asset/Refund.tsx
+++ b/src/modules/asset/Refund.tsx
@@ -198,7 +198,7 @@ const Refund: FunctionComponent = () => {
   }
 
   return (
-    <PaymentSelection 
+    <PaymentSelection
     valueTo={parseFloat(values.to)}
     productId={productId}
     type={'refund'}

--- a/src/modules/asset/components/ConfirmationModal.tsx
+++ b/src/modules/asset/components/ConfirmationModal.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch, SetStateAction } from 'react';
+import React, { Dispatch, SetStateAction, useState } from 'react';
 import { Modal, View, TouchableOpacity, Text } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import AppFonts from '../../../enums/AppFonts';
@@ -20,7 +20,7 @@ interface Props {
   gasCrypto: string
   isApproved: boolean
   createTx: () => void
-  disabled: boolean
+  // disabled: boolean
 }
 
 const ConfirmationModal: React.FC<Props> = ({
@@ -37,9 +37,10 @@ const ConfirmationModal: React.FC<Props> = ({
   gasCrypto,
   isApproved,
   createTx,
-  disabled,
+  // disabled,
 }) => {
   const { t } = useTranslation();
+  const [disabled, setDisabled] = useState(false);
 
   return (
     <Modal
@@ -286,7 +287,11 @@ const ConfirmationModal: React.FC<Props> = ({
                 {`* ${t('assets.check_allowance_guide')}`}
               </Text>}
               <TouchableOpacity
-                onPress={createTx}
+                onPress={() => {
+                  setDisabled(true);
+                  createTx();
+                }}
+                disabled={disabled}
                 style={{
                   backgroundColor: disabled ? AppColors.GREY : AppColors.MAIN,
                   borderRadius: 5,

--- a/src/modules/asset/components/ConfirmationModal.tsx
+++ b/src/modules/asset/components/ConfirmationModal.tsx
@@ -20,7 +20,6 @@ interface Props {
   gasCrypto: string
   isApproved: boolean
   createTx: () => void
-  // disabled: boolean
 }
 
 const ConfirmationModal: React.FC<Props> = ({
@@ -37,7 +36,6 @@ const ConfirmationModal: React.FC<Props> = ({
   gasCrypto,
   isApproved,
   createTx,
-  // disabled,
 }) => {
   const { t } = useTranslation();
   const [disabled, setDisabled] = useState(false);

--- a/src/modules/asset/components/TxInput.tsx
+++ b/src/modules/asset/components/TxInput.tsx
@@ -118,7 +118,7 @@ const TxInput: React.FC<ITxInput> = ({
         >
           <Text
             style={{
-              color: current === 'to' ? AppColors.WHITE : AppColors.DEACTIVATED, //
+              color: current === 'to' ? AppColors.WHITE : AppColors.DEACTIVATED,
               fontFamily: AppFonts.Regular,
             }}
           >
@@ -263,7 +263,6 @@ const TxInput: React.FC<ITxInput> = ({
         gasCrypto={gasCrypto}
         isApproved={isApproved}
         createTx={createTx}
-        // disabled={disabled}
       />
       <OverlayLoading visible={[TxStep.Approving, Platform.OS === 'android' && TxStep.CheckAllowance, TxStep.Creating].includes(step)} />
     </View>

--- a/src/modules/asset/components/TxInput.tsx
+++ b/src/modules/asset/components/TxInput.tsx
@@ -263,7 +263,7 @@ const TxInput: React.FC<ITxInput> = ({
         gasCrypto={gasCrypto}
         isApproved={isApproved}
         createTx={createTx}
-        disabled={disabled}
+        // disabled={disabled}
       />
       <OverlayLoading visible={[TxStep.Approving, Platform.OS === 'android' && TxStep.CheckAllowance, TxStep.Creating].includes(step)} />
     </View>

--- a/src/modules/products/components/ExpandedCard.tsx
+++ b/src/modules/products/components/ExpandedCard.tsx
@@ -82,7 +82,7 @@ const AutoSizedImage: FunctionComponent<{
     if (props.style?.width || props.style?.height) {
       return;
     }
-    safeAsync(Image.getSize(props.source.uri, (originalWidth, originalHeight) => {
+    Image.getSize(props.source.uri, (originalWidth, originalHeight) => {
       finalSize.width = originalWidth;
       finalSize.height = originalHeight;
       if (originalWidth > windowWidth) {
@@ -90,7 +90,6 @@ const AutoSizedImage: FunctionComponent<{
         const ratio = finalSize.width / originalWidth;
         finalSize.height = originalHeight * ratio;
       }
-    })).then(() => {
       setState({ finalSize });
     });
   }, []);


### PR DESCRIPTION
iOS에서 부동산을 구매하려고 '구매하기' 버튼을 눌렀을 때 로딩인디케이터가 나타나지 않아서 버튼을 여러 번 누를 수 있는 문제가 발생했었는데, isApproved와 state를 합쳐도 문제가 해결되진 않았고... 로딩인디케이터가 뜨지 않는 이유도 찾지 못했지만 ㅠㅠ 대신 구매하기 버튼을 누르면 버튼을 비활성화시키는 방식으로 문제를 해결해 보았습니다! 안드로이드에서는 로딩인디케이터가 잘 뜨긴 하지만, 원래 구매하기가 연속으로 여러 번 되면 안 되는 기능이니 버튼을 아예 비활성화시키는 것이 디자인적으로도 괜찮은 방법인 것 같아서요! 

추가) ExpandedCard에서 호출하는 useSafeAsync()를 삭제했습니다. 예전에 워닝이 계속 떠서 추가했던 함수인데, 이 함수가 iOS에서 또 다른 워닝을 띄우기 시작했고 그 사이에 어딘가에서 원래 뜨던 워닝의 원인?이 해결되었는지 이 함수를 삭제해도 더 이상 워닝이 뜨지 않아서요. 