### PR TITLE
(완료 X) UX/UI 버그 수정

### DIFF
--- a/src/modules/staking/Main.tsx
+++ b/src/modules/staking/Main.tsx
@@ -6,6 +6,7 @@ import {
   Text,
   Platform,
   Image,
+  ScrollView,
 } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { useTranslation } from 'react-i18next';
@@ -32,123 +33,125 @@ export const Main: React.FC = () => {
         backgroundColor: AppColors.WHITE,
       }}>
       <AnimatedMainHeader title={t('staking.staking')} scrollY={scrollY} />
-      <View
-        style={{
-          marginTop: 45,
-          alignItems: 'center',
-          paddingHorizontal: 20,
-        }}>
-        <TouchableCardWithShadow
+      <ScrollView alwaysBounceVertical={true}>
+        <View
           style={{
-            width: '100%',
-            height: 180,
-            marginBottom: 30,
-          }}
-          onPress={() => {
-            navigation.navigate(Page.Staking, {
-              screen: StakingPage.CurrentDashboard,
-              params: {
-                cryptoType: CryptoType.EL,
-                rewardCryptoType: CryptoType.ELFI,
-              },
-            });
+            marginTop: 45,
+            alignItems: 'center',
+            paddingHorizontal: 20,
           }}>
-          <View
+          <TouchableCardWithShadow
             style={{
-              flex: 1,
-              justifyContent: 'center',
-              alignItems: 'center',
+              width: '100%',
+              height: 180,
+              marginBottom: 30,
+            }}
+            onPress={() => {
+              navigation.navigate(Page.Staking, {
+                screen: StakingPage.CurrentDashboard,
+                params: {
+                  cryptoType: CryptoType.EL,
+                  rewardCryptoType: CryptoType.ELFI,
+                },
+              });
             }}>
-            <Image
-              source={require('./images/el_staking_visualization.png')}
-              width={304}
-            />
-          </View>
-          <View
+            <View
+              style={{
+                flex: 1,
+                justifyContent: 'center',
+                alignItems: 'center',
+              }}>
+              <Image
+                source={require('./images/el_staking_visualization.png')}
+                width={304}
+              />
+            </View>
+            <View
+              style={{
+                height: 65,
+                borderTopWidth: 1,
+                borderTopColor: AppColors.GREY,
+                padding: 16,
+              }}>
+              <Text
+                style={{
+                  color: AppColors.BLACK,
+                  fontSize: 15,
+                  lineHeight: 17,
+                  fontFamily: AppFonts.Bold,
+                }}>
+                {t('staking.staking_with_type', {
+                  stakingCrypto: CryptoType.EL,
+                })}
+              </Text>
+              <Text
+                style={{
+                  color: AppColors.BLACK,
+                  fontSize: 10,
+                  lineHeight: Platform.OS === 'ios' ? 24 : 20,
+                  fontFamily: AppFonts.Regular,
+                }}>
+                {`${t('staking.schedule')} : ${totalStakingPeriod}`}
+              </Text>
+            </View>
+          </TouchableCardWithShadow>
+          <TouchableCardWithShadow
             style={{
-              height: 65,
-              borderTopWidth: 1,
-              borderTopColor: AppColors.GREY,
-              padding: 16,
+              width: '100%',
+              height: 180,
+              marginBottom: 30,
+            }}
+            onPress={() => {
+              navigation.navigate(Page.Staking, {
+                screen: StakingPage.CurrentDashboard,
+                params: {
+                  cryptoType: CryptoType.ELFI,
+                  rewardCryptoType: CryptoType.DAI,
+                },
+              });
             }}>
-            <Text
+            <View
               style={{
-                color: AppColors.BLACK,
-                fontSize: 15,
-                lineHeight: 17,
-                fontFamily: AppFonts.Bold,
+                flex: 1,
+                justifyContent: 'center',
+                alignItems: 'center',
               }}>
-              {t('staking.staking_with_type', {
-                stakingCrypto: CryptoType.EL,
-              })}
-            </Text>
-            <Text
+              <Image
+                source={require('./images/elfi_staking_visualization.png')}
+                width={304}
+              />
+            </View>
+            <View
               style={{
-                color: AppColors.BLACK,
-                fontSize: 10,
-                lineHeight: Platform.OS === 'ios' ? 24 : 20,
-                fontFamily: AppFonts.Regular,
+                height: 65,
+                borderTopWidth: 1,
+                borderTopColor: AppColors.GREY,
+                padding: 16,
               }}>
-              {`${t('staking.schedule')} : ${totalStakingPeriod}`}
-            </Text>
-          </View>
-        </TouchableCardWithShadow>
-        <TouchableCardWithShadow
-          style={{
-            width: '100%',
-            height: 180,
-            marginBottom: 30,
-          }}
-          onPress={() => {
-            navigation.navigate(Page.Staking, {
-              screen: StakingPage.CurrentDashboard,
-              params: {
-                cryptoType: CryptoType.ELFI,
-                rewardCryptoType: CryptoType.DAI,
-              },
-            });
-          }}>
-          <View
-            style={{
-              flex: 1,
-              justifyContent: 'center',
-              alignItems: 'center',
-            }}>
-            <Image
-              source={require('./images/elfi_staking_visualization.png')}
-              width={304}
-            />
-          </View>
-          <View
-            style={{
-              height: 65,
-              borderTopWidth: 1,
-              borderTopColor: AppColors.GREY,
-              padding: 16,
-            }}>
-            <Text
-              style={{
-                color: AppColors.BLACK,
-                fontSize: 15,
-                lineHeight: 17,
-                fontFamily: AppFonts.Bold,
-              }}>
-              {t('staking.staking_with_type', {
-                stakingCrypto: CryptoType.ELFI,
-              })}
-            </Text>
-            <Text
-              style={{
-                color: AppColors.BLACK,
-                fontSize: 10,
-                lineHeight: Platform.OS === 'ios' ? 24 : 20,
-                fontFamily: AppFonts.Regular,
-              }}>
-              {`${t('staking.schedule')} : ${totalStakingPeriod}`}
-            </Text>
-          </View>
-        </TouchableCardWithShadow>
-      </View>
+              <Text
+                style={{
+                  color: AppColors.BLACK,
+                  fontSize: 15,
+                  lineHeight: 17,
+                  fontFamily: AppFonts.Bold,
+                }}>
+                {t('staking.staking_with_type', {
+                  stakingCrypto: CryptoType.ELFI,
+                })}
+              </Text>
+              <Text
+                style={{
+                  color: AppColors.BLACK,
+                  fontSize: 10,
+                  lineHeight: Platform.OS === 'ios' ? 24 : 20,
+                  fontFamily: AppFonts.Regular,
+                }}>
+                {`${t('staking.schedule')} : ${totalStakingPeriod}`}
+              </Text>
+            </View>
+          </TouchableCardWithShadow>
+        </View>
+      </ScrollView>
     </SafeAreaView>
   );
 };


### PR DESCRIPTION
## 한 일
- staking/Main 페이지에서도 화면이 어느 정도 스크롤 가능하도록 구현
  - 컨텐츠가 차지하는 부분이 스크롤뷰의 크기보다 작을 때도 ~~하도록 하는 건 alwaysBounceVertical라는 속성인데, 이 속성은 iOS에서만 지원합니다. 그런데 동욱님이 예시로 들어 주셨던 알림 탭 화면도 아이폰에서만 그렇게 생긴 거고 안드로이드에서는 화면이 따로 움직이지 않고 로딩인디케이터만 보이기 때문에 안드로이드에서는 스크롤이 안 되어도 괜찮을 것 같습니다. 