### PR TITLE
리워드를 제대로 받아오지 못 하는 버그 해결

### DIFF
--- a/src/modules/dashboard/Main.tsx
+++ b/src/modules/dashboard/Main.tsx
@@ -115,8 +115,8 @@ export const Main: React.FC = () => {
         contract
           .getUserData(round, userAddress || '')
           .then((res: any) => {
-            const stakingAmount = res[2]; // principal
-            const rewardAmount = res[1];
+            const stakingAmount = res.userPrincipal;
+            const rewardAmount = res.userReward;
             if (!stakingAmount.isZero() || !rewardAmount.isZero()) {
               return (
                 <StakingInfoBox

--- a/src/modules/dashboard/Main.tsx
+++ b/src/modules/dashboard/Main.tsx
@@ -109,31 +109,26 @@ export const Main: React.FC = () => {
       setInfoBoxes = setElfiStakingInfoBoxes;
     }
 
-    const tempBoxes = [] as React.ReactNode[];
-    for (let round = 1; round <= 6; round++) {
-      tempBoxes.push(
-        contract
-          .getUserData(round, userAddress || '')
-          .then((res: any) => {
-            const stakingAmount = res.userPrincipal;
-            const rewardAmount = res.userReward;
-            if (!stakingAmount.isZero() || !rewardAmount.isZero()) {
-              return (
-                <StakingInfoBox
-                  key={round}
-                  cryptoType={type}
-                  round={round}
-                  stakingAmount={stakingAmount}
-                  rewardAmount={rewardAmount}
-                />
-              );
-            }
-          })
-          .catch((e) => {
-            console.log(e);
-          }),
+    const tempBoxes = [1, 2, 3, 4, 5, 6].map(async (round) => {
+      const userData = await contract.getUserData(round, userAddress || '');
+      const stakingAmount = userData.userPrincipal;
+      const rewardAmount = await contract.getUserReward(
+        userAddress || '',
+        round,
       );
-    }
+
+      if (!stakingAmount.isZero() || !rewardAmount.isZero()) {
+        return (
+          <StakingInfoBox
+            key={round}
+            cryptoType={type}
+            round={round}
+            stakingAmount={stakingAmount}
+            rewardAmount={rewardAmount}
+          />
+        );
+      }
+    });
 
     setInfoBoxes(await Promise.all(tempBoxes));
   }

--- a/src/modules/staking/Stake.tsx
+++ b/src/modules/staking/Stake.tsx
@@ -247,7 +247,7 @@ const Stake: React.FC = () => {
             })}
           />
           <NumberPadShortcut
-            values={[0.01, 1, 10, 100, 'all']}
+            values={[0.01, 1, 10, 100, 'max']}
             inputValue={value}
             setValue={setValue}
             maxValue={crytoBalance}

--- a/src/modules/staking/Unstake.tsx
+++ b/src/modules/staking/Unstake.tsx
@@ -129,7 +129,7 @@ const Unstake: React.FC = () => {
             invalidText={t('staking.unstaking_value_excess')}
           />
           <NumberPadShortcut
-            values={[0.01, 1, 10, 100, 'all']}
+            values={[0.01, 1, 10, 100, 'max']}
             inputValue={value}
             setValue={setValue}
             maxValue={principal}

--- a/src/modules/staking/components/NumberPadShortcut.tsx
+++ b/src/modules/staking/components/NumberPadShortcut.tsx
@@ -7,7 +7,7 @@ import AppColors from '../../../enums/AppColors';
 import decimalFormatter from '../../../utiles/decimalFormatter';
 
 interface Props {
-  values: (number | 'all')[];
+  values: (number | 'max')[];
   inputValue: string;
   setValue: Dispatch<SetStateAction<string>>;
   maxValue?: number;
@@ -41,7 +41,7 @@ const NumberPadShortcut: React.FC<Props> = ({
             fontSize: 12,
             fontFamily: AppFonts.Medium,
           }}>
-          {value === 'all'
+          {value === 'max'
             ? t('staking.full_amount')
             : `+${commaFormatter(value)}`}
         </Text>
@@ -49,8 +49,8 @@ const NumberPadShortcut: React.FC<Props> = ({
     );
   });
 
-  function addValue(value: number | 'all') {
-    if (value === 'all') {
+  function addValue(value: number | 'max') {
+    if (value === 'max') {
       setValue(String(maxValue));
     } else {
       const newValue = parseFloat(inputValue || '0') + value;


### PR DESCRIPTION
이거 고치기 전에 작게 리팩토링한 것들까지 포함해서 풀리퀘스트 올립니다! 
## 한 일
* 리워드 값을 getUserData()가 아니라 getUserReward()에서 받아옴으로써 일부 사용자의 리워드를 제대로 받아오지 못하는 문제 해결 + Promise 대신 async/await를 사용
* 리팩토링
  * userData를 가져올 때 배열이 아니라 객체 형식으로 가져오도록 변경
  * 전액 버튼을 보여주기 위해 사용하는 value의 이름을 'all'에서 'max'로 변경