### PR TITLE
ETH, BNB 자산페이지에서 보상내역 표시

### DIFF
--- a/src/api/EtherscanClient.ts
+++ b/src/api/EtherscanClient.ts
@@ -133,4 +133,22 @@ export default class EthersacnClient {
       `${ETHERSCAN_API_URL}?module=account&action=tokentx&contractaddress=${tokenAddress}&address=${address}&page=${page}&offset=10&sort=desc&apikey=${ETHERSCAN_API}`,
     );
   };
+
+  static getInternalBnbTx = async (
+    address: string,
+    page: number,
+  ): Promise<AxiosResponse<CryptoTxsResultResponse>> => {
+    return axios.get(
+      `${BSCSCAN_API_URL}?module=account&action=txlistinternal&address=${address}&startblock=0&endblock=99999999&page=${page}&offset=1000&sort=desc&apikey=${BSCSCAN_API}`,
+    );
+  };
+
+  static getInternalEthTx = async (
+    address: string,
+    page: number,
+  ): Promise<AxiosResponse<CryptoTxsResultResponse>> => {
+    return axios.get(
+      `${ETHERSCAN_API_URL}?module=account&action=txlistinternal&address=${address}&startblock=0&endblock=99999999&page=${page}&offset=1000&sort=desc&apikey=${ETHERSCAN_API}`,
+    );
+  };
 }

--- a/src/modules/crypto/Detail.tsx
+++ b/src/modules/crypto/Detail.tsx
@@ -79,29 +79,40 @@ const Detail: React.FC = () => {
   const loadTxs = async () => {
     let newTxs: CryptoTransaction[] = [];
     let res;
+    let test;
     try {
-      if (asset.type === CryptoType.ETH) {
-        res = await EthersacnClient.getEthTransaction(address, state.page);
-      } else if (asset.type === CryptoType.BNB) {
-        res = await EthersacnClient.getBnbTransaction(address, state.page);
-      } else if (asset.type === CryptoType.ELFI) {
-        res = await EthersacnClient.getErc20Transaction(
-          address,
-          ELFI_ADDRESS,
-          state.page,
-        );
-      } else if (asset.type === CryptoType.DAI) {
-        res = await EthersacnClient.getErc20Transaction(
-          address,
-          DAI_ADDRESS,
-          state.page,
-        );
-      } else {
-        res = await EthersacnClient.getErc20Transaction(
-          address,
-          EL_ADDRESS,
-          state.page,
-        );
+      test = await EthersacnClient.getInternalBnbTx(address, state.page);
+      // test.data.result
+      console.log(test.data.result);
+
+      switch (asset.type) {
+        case CryptoType.ETH:
+          res = await EthersacnClient.getEthTransaction(address, state.page);
+          break;
+        case CryptoType.BNB:
+          res = await EthersacnClient.getBnbTransaction(address, state.page);
+          break;
+        case CryptoType.ELFI:
+          res = await EthersacnClient.getErc20Transaction(
+            address,
+            ELFI_ADDRESS,
+            state.page,
+          );
+          break;
+        case CryptoType.DAI:
+          res = await EthersacnClient.getErc20Transaction(
+            address,
+            DAI_ADDRESS,
+            state.page,
+          );
+          break;
+        default:
+          res = await EthersacnClient.getErc20Transaction(
+            address,
+            EL_ADDRESS,
+            state.page,
+          );
+          break;
       }
 
       if (res.data.result.length === 0 && state.page >= 2) {

--- a/src/modules/crypto/Detail.tsx
+++ b/src/modules/crypto/Detail.tsx
@@ -123,15 +123,17 @@ const Detail: React.FC = () => {
         alert(t('dashboard.last_transaction'));
         return;
       }
+      newTxs = res.data.result.map((tx: Transaction) =>
+        txResponseToTx(tx, address),
+      );
       if (rewardTx) {
         newRewardTx = rewardTx.data.result.map((tx: Transaction) =>
           txResponseToTx(tx, address),
         );
+        newTxs = [...newTxs, ...newRewardTx].sort(
+          (tx, nTx) => (nTx.blockNumber || 0) - (tx.blockNumber || 0),
+        );
       }
-      newTxs = res.data.result.map((tx: Transaction) =>
-        txResponseToTx(tx, address),
-      );
-      newTxs = [...newTxs, ...newRewardTx];
     } catch {
       if (state.page !== 1) {
         alert(t('dashboard.last_transaction'));
@@ -151,9 +153,7 @@ const Detail: React.FC = () => {
             page: 2,
             lastPage: false,
             transactions: isCurrentPendingTx
-              ? newTxs.sort(
-                  (tx, nTx) => (nTx.blockNumber || 0) - (tx.blockNumber || 0),
-                )
+              ? newTxs
               : pendingTxs.concat(newTxs),
             loading: false,
           });

--- a/src/modules/crypto/Detail.tsx
+++ b/src/modules/crypto/Detail.tsx
@@ -78,7 +78,7 @@ const Detail: React.FC = () => {
 
   const loadTxs = async () => {
     let newTxs: CryptoTransaction[] = [];
-    let newRewardTx: CryptoTransaction[] = [];
+    let newRewardTxs: CryptoTransaction[] = [];
     let res;
     let rewardTx;
     try {
@@ -111,13 +111,15 @@ const Detail: React.FC = () => {
             state.page,
           );
           break;
-        default:
+        case CryptoType.EL:
           res = await EthersacnClient.getErc20Transaction(
             address,
             EL_ADDRESS,
             state.page,
           );
           break;
+        default:
+          return;
       }
       if (res.data.result.length === 0 && state.page >= 2) {
         alert(t('dashboard.last_transaction'));
@@ -127,10 +129,10 @@ const Detail: React.FC = () => {
         txResponseToTx(tx, address),
       );
       if (rewardTx) {
-        newRewardTx = rewardTx.data.result.map((tx: Transaction) =>
+        newRewardTxs = rewardTx.data.result.map((tx: Transaction) =>
           txResponseToTx(tx, address),
         );
-        newTxs = [...newTxs, ...newRewardTx].sort(
+        newTxs = [...newTxs, ...newRewardTxs].sort(
           (tx, nTx) => (nTx.blockNumber || 0) - (tx.blockNumber || 0),
         );
       }

--- a/src/types/CryptoTransaction.ts
+++ b/src/types/CryptoTransaction.ts
@@ -13,7 +13,7 @@ type CryptoTransaction = {
   value: string;
   txHash?: string;
   createdAt: string;
-  blockNumber: number | undefined;
+  blockNumber?: number;
   status?: TxStatus;
   cryptoType?: CryptoType;
   productId?: number;

--- a/src/utiles/LoadLagacyDetail.ts
+++ b/src/utiles/LoadLagacyDetail.ts
@@ -1,3 +1,4 @@
+import { utils } from 'ethers';
 import CryptoType from '../enums/CryptoType';
 import CryptoTransaction from '../types/CryptoTransaction';
 import Server from '../api/server';
@@ -8,7 +9,6 @@ import EthersacnClient from '../api/EtherscanClient';
 import txResponseToTx from './txResponseToTx';
 import Product from '../types/Product';
 import { getAssetTokenContract, getBscAssetTokenContract } from './getContract';
-import { utils } from 'ethers';
 
 class LoadDetail {
   async ownershipDetail(

--- a/src/utiles/createTransferTx.ts
+++ b/src/utiles/createTransferTx.ts
@@ -1,14 +1,14 @@
 import React, { useContext, useEffect, useState } from 'react';
+import { TransactionResponse } from '@ethersproject/providers';
+import { useNavigation } from '@react-navigation/native';
+import { Contract } from '@ethersproject/contracts';
 import CryptoType from '../enums/CryptoType';
 import TransferType from '../enums/TransferType';
 import { purchaseProduct, sendCryptoAsset } from './createTransction';
 import useTxHandler from '../hooks/useTxHandler';
 import PriceContext from '../contexts/PriceContext';
 import WalletContext from '../contexts/WalletContext';
-import { TransactionResponse } from '@ethersproject/providers';
 import NetworkType from '../enums/NetworkType';
-import { useNavigation } from '@react-navigation/native';
-import { Contract } from '@ethersproject/contracts';
 import useErcContract from '../hooks/useErcContract';
 
 export default function createTransferTx(
@@ -84,7 +84,7 @@ export default function createTransferTx(
           ),
         );
       } else {
-        let ercContract = setErcContract(type);
+        const ercContract = setErcContract(type);
         setResTx(
           await sendCryptoAsset(
             gasPrice,

--- a/src/utiles/getTokenLink.ts
+++ b/src/utiles/getTokenLink.ts
@@ -1,5 +1,5 @@
-import NetworkType from '../enums/NetworkType';
 import { ETH_NETWORK } from 'react-native-dotenv';
+import NetworkType from '../enums/NetworkType';
 
 const getTokenLink = (address?: string, networkType?: NetworkType): string => {
   return networkType && networkType === NetworkType.BSC

--- a/src/utiles/getTxScanLink.ts
+++ b/src/utiles/getTxScanLink.ts
@@ -1,5 +1,5 @@
-import NetworkType from '../enums/NetworkType';
 import { ETH_NETWORK } from 'react-native-dotenv';
+import NetworkType from '../enums/NetworkType';
 
 const getTxScanLink = (txHash?: string, networkType?: NetworkType): string => {
   return networkType && networkType === NetworkType.BSC

--- a/src/utiles/txResponseToTx.ts
+++ b/src/utiles/txResponseToTx.ts
@@ -1,8 +1,8 @@
 import { BigNumber, utils } from 'ethers';
-import { Transaction } from '../types/CryptoTxsResponse';
 import Bignumberjs from 'bignumber.js';
-import CryptoTransaction from '../types/CryptoTransaction';
 import moment from 'moment';
+import { Transaction } from '../types/CryptoTxsResponse';
+import CryptoTransaction from '../types/CryptoTransaction';
 
 const txResponseToTx = (
   tx: Transaction,


### PR DESCRIPTION
- api를 추가하여 보상받은 내역이 있으면 블록넘버로 정렬하여 보여주도록 구현
- 트랜잭션 리스트 데이터를 가져올 때 if문에서 switch문으로 변경

production으로 테스트 했을 때 보상이 없어서 그런건지 api 두 개 동시에 호출 했을 때 괜찮았습니다.